### PR TITLE
Refact: edit columns

### DIFF
--- a/apps/etl/src/etl.service.ts
+++ b/apps/etl/src/etl.service.ts
@@ -51,11 +51,11 @@ export class EtlService {
             for (const item of extracted) {
                 const uniqueId = this.generatePoolId();
                 await this.poolInfoModel.create({
-                    poolId: uniqueId,
+                    pool_code: uniqueId,
                     title: item.title,
                     address: item.address,
                     pbid: item.pbid,
-                    createdAt: new Date(),
+                    created_at: new Date(),
                 });
             }
 
@@ -190,16 +190,16 @@ export class EtlService {
                     for (const schedule of schedules) {
                         await this.dailySwimScheduleModel.create({
                             ...schedule,
-                            pool_code: doc.poolId,
-                            createdAt: new Date(),
+                            pool_code: doc.pool_code,
+                            created_at: new Date(),
                         });
                     }
                     this.logger.log(`Inserted ${schedules.length} schedules for pbid=${doc.pbid}`);
                 } else {
                     await this.dailySwimScheduleModel.create({
                         ...schedules,
-                        pool_code: doc.poolId,
-                        createdAt: new Date(),
+                        pool_code: doc.pool_code,
+                        created_at: new Date(),
                     });
                     this.logger.log(`Inserted 1 schedule object for pbid=${doc.pbid}`);
                 }
@@ -215,5 +215,46 @@ export class EtlService {
         const imgUrl = '';
         const text = await this.ocrService.recognizeKoreanText(imgUrl);
         this.logger.log( { text } );
+    }
+
+    async renamePoolFields() {
+        await this.poolInfoModel.updateMany(
+            {},
+            {
+                $rename: {
+                    poolId: 'pool_code',
+                    createdAt: 'created_at',
+                },
+            },
+        );
+
+        this.logger.log('Renamed fields (poolId -> pool_code, createdAt -> created_at) for all docs in pool_info');
+    }
+
+    async renameSeoulPoolFields() {
+        await this.seoulPoolInfoModel.updateMany(
+            {},
+            {
+                $rename: {
+                    poolId: 'pool_code',
+                    createdAt: 'created_at',
+                },
+            },
+        );
+
+        this.logger.log('Renamed fields (poolId -> pool_code, createdAt -> created_at) for all docs in seoul_pool_info');
+    }
+
+    async renameDailySwimScheduleFields() {
+        await this.dailySwimScheduleModel.updateMany(
+            {},
+            {
+                $rename: {
+                    createdAt: 'created_at',
+                },
+            },
+        ).exec();
+
+        this.logger.log('Renamed fields (createdAt -> created_at) for all docs in daily_swim_schedule');
     }
 }

--- a/apps/etl/src/etl.service.ts
+++ b/apps/etl/src/etl.service.ts
@@ -216,45 +216,4 @@ export class EtlService {
         const text = await this.ocrService.recognizeKoreanText(imgUrl);
         this.logger.log( { text } );
     }
-
-    async renamePoolFields() {
-        await this.poolInfoModel.updateMany(
-            {},
-            {
-                $rename: {
-                    poolId: 'pool_code',
-                    createdAt: 'created_at',
-                },
-            },
-        );
-
-        this.logger.log('Renamed fields (poolId -> pool_code, createdAt -> created_at) for all docs in pool_info');
-    }
-
-    async renameSeoulPoolFields() {
-        await this.seoulPoolInfoModel.updateMany(
-            {},
-            {
-                $rename: {
-                    poolId: 'pool_code',
-                    createdAt: 'created_at',
-                },
-            },
-        );
-
-        this.logger.log('Renamed fields (poolId -> pool_code, createdAt -> created_at) for all docs in seoul_pool_info');
-    }
-
-    async renameDailySwimScheduleFields() {
-        await this.dailySwimScheduleModel.updateMany(
-            {},
-            {
-                $rename: {
-                    createdAt: 'created_at',
-                },
-            },
-        ).exec();
-
-        this.logger.log('Renamed fields (createdAt -> created_at) for all docs in daily_swim_schedule');
-    }
 }

--- a/apps/etl/src/main.ts
+++ b/apps/etl/src/main.ts
@@ -1,14 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { EtlModule } from './etl.module';
-import { EtlService } from "./etl.service";
 
 async function bootstrap() {
     const app = await NestFactory.create(EtlModule);
     await app.init();
-
-    const etlService = app.get(EtlService);
-    await etlService.renamePoolFields();
-    await etlService.renameSeoulPoolFields();
-    await etlService.renameDailySwimScheduleFields();
 }
 bootstrap();

--- a/apps/etl/src/main.ts
+++ b/apps/etl/src/main.ts
@@ -1,8 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { EtlModule } from './etl.module';
+import { EtlService } from "./etl.service";
 
 async function bootstrap() {
     const app = await NestFactory.create(EtlModule);
     await app.init();
+
+    const etlService = app.get(EtlService);
+    await etlService.renamePoolFields();
+    await etlService.renameSeoulPoolFields();
+    await etlService.renameDailySwimScheduleFields();
 }
 bootstrap();

--- a/libs/db/src/db.module.ts
+++ b/libs/db/src/db.module.ts
@@ -1,11 +1,23 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PoolInfo, PoolInfoSchema } from './schemas/pool-info.schema';
-import {DailySwimSchedule, DailySwimScheduleSchema} from "@libs/db/schemas/daily-swim-schedule.schema";
-import {SeoulPoolInfo, SeoulPoolInfoSchema} from "@libs/db/schemas/seoul-pool-info.schema";
+import { DailySwimSchedule, DailySwimScheduleSchema } from "@libs/db/schemas/daily-swim-schedule.schema";
+import { SeoulPoolInfo, SeoulPoolInfoSchema } from "@libs/db/schemas/seoul-pool-info.schema";
+import { ConfigModule, ConfigService } from "@nestjs/config";
 
 @Module({
     imports: [
+        ConfigModule.forRoot({
+            isGlobal: true,
+            envFilePath: '.env',
+        }),
+        MongooseModule.forRootAsync({
+            imports: [ConfigModule],
+            useFactory: (configService: ConfigService) => ({
+                uri: configService.get<string>('MONGO_URI') || 'mongodb://localhost:27017/dbname',
+            }),
+            inject: [ConfigService],
+        }),
         MongooseModule.forFeature([
             {
                 name: PoolInfo.name,

--- a/libs/db/src/schemas/daily-swim-schedule.schema.ts
+++ b/libs/db/src/schemas/daily-swim-schedule.schema.ts
@@ -23,6 +23,9 @@ export class DailySwimSchedule extends Document {
 
     @Prop()
     createdAt?: Date;
+
+    @Prop()
+    created_at?: Date;
 }
 
 export const DailySwimScheduleSchema = SchemaFactory.createForClass(DailySwimSchedule);

--- a/libs/db/src/schemas/pool-info.schema.ts
+++ b/libs/db/src/schemas/pool-info.schema.ts
@@ -4,7 +4,7 @@ import { Document } from 'mongoose';
 @Schema()
 export class PoolInfo extends Document {
     @Prop()
-    poolId?: string;
+    pool_code?: string;
 
     @Prop()
     title?: string;
@@ -16,7 +16,7 @@ export class PoolInfo extends Document {
     pbid?: string;
 
     @Prop()
-    createdAt?: Date;
+    created_at?: Date;
 }
 
 export const PoolInfoSchema = SchemaFactory.createForClass(PoolInfo);

--- a/libs/db/src/schemas/seoul-pool-info.schema.ts
+++ b/libs/db/src/schemas/seoul-pool-info.schema.ts
@@ -4,7 +4,7 @@ import { Document } from 'mongoose';
 @Schema()
 export class SeoulPoolInfo extends Document {
     @Prop()
-    poolId?: string;
+    pool_code?: string;
 
     @Prop()
     title?: string;
@@ -16,7 +16,7 @@ export class SeoulPoolInfo extends Document {
     pbid?: string;
 
     @Prop()
-    createdAt?: Date;
+    created_at?: Date;
 }
 
 export const SeoulPoolInfoSchema = SchemaFactory.createForClass(SeoulPoolInfo);


### PR DESCRIPTION
- poolId -> pool_code
- createAt -> create_at

Originally, I was going to use a loop to replace each one, but I realized that I could use $rename instead. 
In Typescript, I can use it like this
```typescript
await this.poolInfoModel.updateMany(
    {},
    {
        $rename: {
            poolId: 'pool_code',
            createdAt: 'created_at',
        },
    },
);
```

In order to write process.env.MONGO_URI, I need to import an additional ConfigModule in module.ts. Otherwise, it won't be recognized.
```typescript
ConfigModule.forRoot({
    isGlobal: true,
    envFilePath: '.env',
}),
```

If you are using the mongoose model, you must explicitly declare the database to use for the connection endpoint, otherwise it will pick up the test database that is set as the default.
```text
MONGO_URI=mongodb+srv://my_id:my_password@my_mongo_db_endpoint/plz_write_what_you_want_to_use_database
```