### PR TITLE
Refact: deleted crawling about swimming pool list considering pagination

### DIFF
--- a/apps/etl/src/etl.service.ts
+++ b/apps/etl/src/etl.service.ts
@@ -27,55 +27,6 @@ export class EtlService {
         private readonly dailySwimScheduleModel: Model<DailySwimSchedule>,
     ) {}
 
-    async crawlPoolData() {
-        this.logger.log('Starting pool data crawling...');
-
-        const allResults = [];
-
-        let pageIndex = 1;
-        let hasMoreData = true;
-
-        while (hasMoreData) {
-            const data = await this.scraperService.fetchPoolInfo(pageIndex);
-
-            const extracted = data.map((item) => {
-                return {
-                    title: item.title,
-                    address: item.address,
-                    pbid: item.pbid,
-                };
-            });
-
-            allResults.push(...extracted);
-
-            for (const item of extracted) {
-                const uniqueId = this.generatePoolId();
-                await this.poolInfoModel.create({
-                    pool_code: uniqueId,
-                    title: item.title,
-                    address: item.address,
-                    pbid: item.pbid,
-                    created_at: new Date(),
-                });
-            }
-
-            if (data.length === 0) {
-                this.logger.log('No more data found. Stopping.');
-                hasMoreData = false;
-            } else {
-                pageIndex++;
-            }
-            if (pageIndex > 94) {
-                this.logger.warn('Reached page limit. Stopping...');
-                hasMoreData = false;
-            }
-
-            await this.delay(2000);
-        }
-
-        this.logger.log('Completed pool data crawling.');
-    }
-
     private delay(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }

--- a/libs/scraper/src/scraper.service.ts
+++ b/libs/scraper/src/scraper.service.ts
@@ -63,34 +63,4 @@ export class ScraperService {
         }
         return url;
     }
-
-    async fetchPoolInfo(pageIndex: number = 1, searchInfo: string = ''): Promise<{
-        title: string,
-        address: string,
-        pbid: string,
-    }[]> {
-        const url = process.env.CRAWLING_TARGET_URL;
-        if (!url) {
-            throw new Error('CRAWLING_TARGET_URL is not defined in the environment variables.');
-        }
-
-        const formData = new URLSearchParams();
-        formData.append('searchInfo', searchInfo);
-        formData.append('pageIndex', pageIndex.toString());
-
-        try {
-            const response = await axios.post(url, formData.toString(), {
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                },
-            });
-
-            this.logger.log(`Fetched data for pageIndex=${pageIndex}, count=${response.data.data?.length ?? 0}`);
-            return response.data.data;
-        } catch (error) {
-            this.logger.error(`Error fetching pool info for pageIndex=${pageIndex}`, error);
-            throw error;
-        }
-    }
-
 }


### PR DESCRIPTION
I initially attempted to use LLM prompting to extract free swimming information regardless of the DOM structure across multiple sites. However, I shifted the strategy to crawl a specific site that provides an organized swimming information list.
(ref. https://github.com/jeongkichang/swimming-schedule-nest/pull/5)

The swimming list is rendered with pagination, and I successfully implemented a method to iterate through each page using query strings. From the swimming list, I extracted the title, address, and pbid properties and stored them in our database.

Since there is no longer a need to crawl the swimming list, the previously used code for this purpose will be removed.

However, I plan to periodically crawl detailed swimming information using the pbid stored in our database. For cases where a page becomes invalid, additional considerations will be required to determine an appropriate response strategy.